### PR TITLE
refactor: Main 및 RecommendKeyword css 수정, crlf lf관련 린트설정 추가

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -81,6 +81,12 @@
         "ts": "never",
         "tsx": "never"
       }
+    ],
+    "prettier/prettier": [
+      "error",
+      {
+        "endOfLine": "auto"
+      }
     ]
   }
 }

--- a/src/routes/Footer/Footer.module.scss
+++ b/src/routes/Footer/Footer.module.scss
@@ -38,7 +38,7 @@ footer {
     }
   }
 
-  @include responsive.before($media:1039px) {
+  @include responsive.before($media: 1039px) {
     .footerWrapper {
       display: block;
 

--- a/src/routes/Footer/Footer.module.scss
+++ b/src/routes/Footer/Footer.module.scss
@@ -24,7 +24,7 @@ footer {
 
       li {
         margin-bottom: 16px;
-        font-size: 1rem;
+        font-size: 16px;
 
         a {
           color: colors.$ALUMINIUM_GRAY;
@@ -32,7 +32,7 @@ footer {
 
         p,
         address {
-          font-size: 0.875rem;
+          font-size: 14px;
         }
       }
     }

--- a/src/routes/Header/Gnb/GNB.module.scss
+++ b/src/routes/Header/Gnb/GNB.module.scss
@@ -32,7 +32,7 @@ nav {
   }
 }
 
-@include responsive.before($media:1039px) {
+@include responsive.before($media: 1039px) {
   .gnbMobileButton {
     display: block;
   }

--- a/src/routes/Header/Gnb/GNB.module.scss
+++ b/src/routes/Header/Gnb/GNB.module.scss
@@ -18,7 +18,7 @@ nav {
     li {
       button {
         padding: 0 16px;
-        font-size: 1rem;
+        font-size: 16px;
         font-weight: 400;
         line-height: 1.6;
         color: colors.$GRAY_NAVY;

--- a/src/routes/Main/Main.module.scss
+++ b/src/routes/Main/Main.module.scss
@@ -20,78 +20,62 @@
   }
 
   .formBox {
+    position: relative;
     display: flex;
+    align-items: center;
     justify-content: space-between;
     width: 100%;
-    overflow: hidden;
     background-color: colors.$WHITE;
     border-radius: 42px;
 
-    .searchBox {
-      display: flex;
-      flex: 1;
-      gap: 10px;
-      align-items: center;
-      padding: 20px 24px;
-      background-color: colors.$WHITE;
-
-      input {
-        flex: 1;
-        font-size: 18px;
-      }
+    .searchIcon {
+      margin-right: 10px;
+      margin-left: 24px;
     }
 
-    button {
+    input {
+      flex: 1;
+      font-size: 18px;
+    }
+
+    .searchButton {
       @include flexbox.flexbox;
       padding: 18px 32px;
       font-size: 18px;
       font-weight: 700;
       color: colors.$WHITE;
       background-color: colors.$DEEP_BLUE;
+      border-top-right-radius: 42px;
+      border-bottom-right-radius: 42px;
     }
-  }
-}
 
-.listContainer {
-  top: 100%;
-  left: 0;
-  display: flex;
-  flex-direction: column;
-  width: 100%;
-  padding: 24px 24px 16px;
-  margin-top: 8px;
-  font-size: 13px;
-  background-color: colors.$WHITE;
-  border-radius: 20px;
-
-  h2 {
-    line-height: 1.6;
-    color: colors.$GRAY6;
-  }
-
-  ul {
-    li {
+    .listContainer {
+      position: absolute;
+      top: 60px;
+      left: 0;
+      z-index: 10;
       display: flex;
-      gap: 10px;
-      align-items: center;
-      margin-top: 10px;
+      flex-direction: column;
+      width: 100%;
+      padding: 24px 24px 16px;
+      margin-top: 8px;
+      font-size: 13px;
+      background-color: colors.$WHITE;
+      border-radius: 20px;
 
-      button {
-        overflow: hidden;
-        font-size: 16px;
-        line-height: 30px;
-        text-overflow: ellipsis;
-        white-space: nowrap;
+      .listHeader {
+        line-height: 1.6;
+        color: colors.$GRAY6;
+      }
+
+      p {
+        line-height: 2;
       }
     }
   }
-
-  p {
-    line-height: 2;
-  }
 }
 
-@include responsive.before($media:1039px) {
+@include responsive.before($media: 1039px) {
   .main {
     max-width: 500px;
 
@@ -104,38 +88,31 @@
       height: 46px;
       box-shadow: 0 2px 2px colors.$SHADOW_COLOR;
 
-      .searchBox {
-        input {
-          font-size: 14px;
-        }
+      input {
+        margin-left: 24px;
+        font-size: 14px;
       }
 
-      button {
+      .searchButton {
+        height: 46px;
         background-color: colors.$WHITE;
       }
-    }
-  }
 
-  .listContainer {
-    ul {
-      li {
-        button {
-          font-size: 14px;
-          line-height: 28px;
+      .listContainer {
+        top: 45px;
+
+        p {
+          line-height: 2;
         }
       }
-    }
-
-    p {
-      line-height: 2;
     }
   }
 }
 
-.mobile {
+.forMobileScreen {
   @include visual.desktopHidden;
 }
 
-.pc {
+.forPcScreen {
   @include visual.mobileHidden;
 }

--- a/src/routes/Main/RecommendKeyword/RecommendKeyword.module.scss
+++ b/src/routes/Main/RecommendKeyword/RecommendKeyword.module.scss
@@ -1,4 +1,5 @@
 @use '/src/styles/constants/colors';
+@use '/src/styles/mixins/responsive';
 
 .selected {
   display: flex;

--- a/src/routes/Main/RecommendKeyword/RecommendKeyword.module.scss
+++ b/src/routes/Main/RecommendKeyword/RecommendKeyword.module.scss
@@ -1,14 +1,36 @@
 @use '/src/styles/constants/colors';
 
 .selected {
-  button mark {
-    font-weight: 700;
-    background-color: transparent;
+  display: flex;
+  gap: 10px;
+  align-items: center;
+  margin-top: 10px;
+
+  button {
+    overflow: hidden;
+    font-size: 16px;
+    line-height: 30px;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+
+    & mark {
+      font-weight: 700;
+      background-color: transparent;
+    }
   }
 
   &:focus-within {
     padding: 0 10px;
     background-color: colors.$GRAYE;
     border-radius: 10px;
+  }
+}
+
+@include responsive.before($media: 1039px) {
+  .selected {
+    button {
+      font-size: 14px;
+      line-height: 28px;
+    }
   }
 }

--- a/src/routes/Main/SectionSubscribe/SectionSubscribe.module.scss
+++ b/src/routes/Main/SectionSubscribe/SectionSubscribe.module.scss
@@ -16,7 +16,7 @@ section {
 
     h2 {
       margin-bottom: 16px;
-      font-size: 1.125rem;
+      font-size: 18px;
       font-weight: 700;
       line-height: 1.6;
       color: colors.$WHITE;
@@ -29,7 +29,7 @@ section {
 
     button {
       padding: 10px 24px;
-      font-size: 1rem;
+      font-size: 16px;
       line-height: 1.6;
       color: colors.$FRENCH_BLUE;
       letter-spacing: -0.018em;
@@ -62,7 +62,7 @@ section {
 
       h2 {
         margin-bottom: 16px;
-        font-size: 0.875rem;
+        font-size: 14px;
         font-weight: 400;
         color: colors.$BLACK;
 
@@ -73,7 +73,7 @@ section {
 
       button {
         padding: 6px 16px;
-        font-size: 0.875rem;
+        font-size: 14px;
         color: colors.$WHITE;
         background-color: colors.$DEEP_BLUE;
       }

--- a/src/routes/Main/SectionSubscribe/SectionSubscribe.module.scss
+++ b/src/routes/Main/SectionSubscribe/SectionSubscribe.module.scss
@@ -88,10 +88,10 @@ section {
   }
 }
 
-.mobile {
+.forMobileScreen {
   @include visual.desktopHidden;
 }
 
-.pc {
+.forPcScreen {
   @include visual.mobileHidden;
 }

--- a/src/routes/Main/SectionSubscribe/SectionSubscribe.module.scss
+++ b/src/routes/Main/SectionSubscribe/SectionSubscribe.module.scss
@@ -47,7 +47,7 @@ section {
   }
 }
 
-@include responsive.before($media:1039px) {
+@include responsive.before($media: 1039px) {
   section {
     background-color: colors.$SKY_BLUE;
 

--- a/src/routes/Main/SectionSubscribe/index.tsx
+++ b/src/routes/Main/SectionSubscribe/index.tsx
@@ -12,8 +12,8 @@ const SectionSubscribe = () => {
           <em>문자로 알려드려요.</em>
         </h2>
         <button type='button'>임상시험 소식받기</button>
-        <DecorationMobileIcon className={cx(styles.mobile, styles.decorationSVG)} />
-        <DecorationPcIcon className={cx(styles.pc, styles.decorationSVG)} />
+        <DecorationMobileIcon className={cx(styles.forMobileScreen, styles.decorationSVG)} />
+        <DecorationPcIcon className={cx(styles.forPcScreen, styles.decorationSVG)} />
       </div>
     </section>
   )

--- a/src/routes/Main/index.tsx
+++ b/src/routes/Main/index.tsx
@@ -1,6 +1,7 @@
 import styles from './Main.module.scss'
 import { ChangeEvent, FormEvent, Suspense, useMemo, useState } from 'react'
 import { debounce } from 'lodash'
+import cx from 'classnames'
 
 import { useAppDispatch } from 'hooks/useAppDispatch'
 import { setKeyword } from 'states/search'
@@ -31,23 +32,22 @@ const Main = () => {
           <br /> 온라인으로 참여하기
         </h1>
         <form className={styles.formBox} onSubmit={onSubmitHandler}>
-          <div className={styles.searchBox}>
-            <SearchIcon className={styles.pc} />
-            <input type='text' value={inputValue} onChange={onChangeHandler} placeholder='질환명을 입력해주세요.' />
-          </div>
-          <button type='submit'>
-            <span className={styles.pc}>검색</span>
-            <SearchIcon className={styles.mobile} />
+          <SearchIcon className={cx(styles.forPcScreen, styles.searchIcon)} />
+          <input type='text' value={inputValue} onChange={onChangeHandler} placeholder='질환명을 입력해주세요.' />
+
+          <button type='submit' className={styles.searchButton}>
+            <span className={styles.forPcScreen}>검색</span>
+            <SearchIcon className={styles.forMobileScreen} />
           </button>
+          {inputValue && (
+            <div className={styles.listContainer}>
+              <p className={styles.listHeader}>추천 검색어</p>
+              <Suspense fallback={<p>로딩중</p>}>
+                <RecommendKeyword setInputValue={setInputValue} />
+              </Suspense>
+            </div>
+          )}
         </form>
-        {inputValue && (
-          <div className={styles.listContainer}>
-            <h2>추천 검색어</h2>
-            <Suspense fallback={<p>로딩중</p>}>
-              <RecommendKeyword setInputValue={setInputValue} />
-            </Suspense>
-          </div>
-        )}
       </main>
       <SectionSubscribe />
     </>

--- a/src/styles/mixins/_visual.scss
+++ b/src/styles/mixins/_visual.scss
@@ -1,11 +1,11 @@
 @mixin mobileHidden {
-  @media screen and (max-width: 999px) {
+  @media screen and (max-width: 1039px) {
     display: none !important;
   }
 }
 
 @mixin desktopHidden {
-  @media screen and (min-width: 1000px) {
+  @media screen and (min-width: 1040px) {
     display: none !important;
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -8089,7 +8089,7 @@ sanitize.css@*:
   resolved "https://registry.yarnpkg.com/sanitize.css/-/sanitize.css-13.0.0.tgz#2675553974b27964c75562ade3bd85d79879f173"
   integrity sha512-ZRwKbh/eQ6w9vmTjkuG0Ioi3HBwPFce0O+v//ve+aOq1oeCy7jMV2qzzAlpsNuqpqCBjjriM1lbtZbF/Q8jVyA==
 
-sass-loader@12.6.0, sass-loader@^12.3.0:
+sass-loader@^12.3.0, sass-loader@^12.6.0:
   version "12.6.0"
   resolved "https://registry.yarnpkg.com/sass-loader/-/sass-loader-12.6.0.tgz#5148362c8e2cdd4b950f3c63ac5d16dbfed37bcb"
   integrity sha512-oLTaH0YCtX4cfnJZxKSLAyglED0naiYfNG1iXfU5w1LNZ+ukoA5DtyDIN5zmKVZwYNJP4KRc5Y3hkWga+7tYfA==

--- a/yarn.lock
+++ b/yarn.lock
@@ -8089,7 +8089,7 @@ sanitize.css@*:
   resolved "https://registry.yarnpkg.com/sanitize.css/-/sanitize.css-13.0.0.tgz#2675553974b27964c75562ade3bd85d79879f173"
   integrity sha512-ZRwKbh/eQ6w9vmTjkuG0Ioi3HBwPFce0O+v//ve+aOq1oeCy7jMV2qzzAlpsNuqpqCBjjriM1lbtZbF/Q8jVyA==
 
-sass-loader@^12.3.0, sass-loader@^12.6.0:
+sass-loader@12.6.0, sass-loader@^12.3.0:
   version "12.6.0"
   resolved "https://registry.yarnpkg.com/sass-loader/-/sass-loader-12.6.0.tgz#5148362c8e2cdd4b950f3c63ac5d16dbfed37bcb"
   integrity sha512-oLTaH0YCtX4cfnJZxKSLAyglED0naiYfNG1iXfU5w1LNZ+ukoA5DtyDIN5zmKVZwYNJP4KRc5Y3hkWga+7tYfA==


### PR DESCRIPTION
Pull request 내용

Main 및 RecommendKeyword에 해당하는 style들이 Main.module.scss에 섞여있어서 이를 분할하는 작업을 수행하였습니다. 
그리고 crlf,lf 문제가 lint에서 계속 잡혀서 관련 설정을 추가하였습니다.

(수행하는 동안 클래스 명이 필요한 부분에 클래스를 수정 및 추가하였습니다. )

스타일 수정 내용
- Main 페이지의 searchBox로 사용된 div tag는 style용으로 사용된 태그로 보여 div tag를 삭제하고 스타일을 조정하였습니다.
- Main 페이지 > formBox > button tag 스타일 수정
  -> 스타일을 줄 때 tag 명으로 스타일을 주게될 경우 다른 페이지의 스타일에도 영향을 미치게 되어 필요한 부분에 클래스명을 추가하였습니다.
- Main 페이지 > .listContainer(키워드 추천 ul li 부분)은 position absolute로 변경하였습니다.
- src/styels/mixins/_visual에 px 설정 부분을 저희 페이지 반응형 픽셀에 맞게 조정하였습니다.

